### PR TITLE
Implement 2-3 Sugar free alternatives logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/group/SwapSmart/config/SecurityConfig.java
+++ b/src/main/java/com/group/SwapSmart/config/SecurityConfig.java
@@ -3,10 +3,8 @@ package com.group.SwapSmart.config;
 import org.springframework.context.annotation.Configuration;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
 
 @Configuration
 public class SecurityConfig {
@@ -20,3 +18,5 @@ public class SecurityConfig {
     }
     
 }
+
+

--- a/src/main/java/com/group/SwapSmart/controller/AlternativesController.java
+++ b/src/main/java/com/group/SwapSmart/controller/AlternativesController.java
@@ -1,0 +1,34 @@
+package com.group.SwapSmart.controller;
+
+import com.group.SwapSmart.entity.Product;
+import com.group.SwapSmart.service.AlternativesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/alts")
+public class AlternativesController {
+
+    private final AlternativesService alternativesService;
+
+    // Constructor injection
+    public AlternativesController(AlternativesService alternativesService) {
+        this.alternativesService = alternativesService;
+    }
+
+    // GET /api/alts/{barcode}
+    // Takes a barcode and returns a list of sugar free alternatives
+    @GetMapping("/{barcode}")
+    public ResponseEntity<List<Product>> getSugarFreeAlts(@PathVariable String barcode) {
+
+        // Normalize barcode to 13 digits with leading zero if needed
+        if (barcode.length() == 12) {
+            barcode = "0" + barcode;
+        }
+
+        List<Product> alternatives = alternativesService.getAlternatives(barcode);
+        return ResponseEntity.ok(alternatives);
+    }
+
+}

--- a/src/main/java/com/group/SwapSmart/entity/Product.java
+++ b/src/main/java/com/group/SwapSmart/entity/Product.java
@@ -1,0 +1,90 @@
+package com.group.SwapSmart.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "products")
+public class Product {
+
+    // Primary key
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+    // Barcode is unique since we use it to check if product is already cached
+    @Column(unique = true, nullable = false)
+    private String barcode;
+
+    // Product name
+    @Column
+    private String productName;
+
+    // Category used for alternatives search
+    @Column
+    private String category;
+
+    // Sugar value per 100g
+    @Column
+    private Double sugars100g;
+
+    // Country filter
+    @Column
+    private String country;
+
+    // Timestamp of when product was first checked/scanned from API
+    @Column
+    private LocalDateTime lastChecked;
+
+    // Getters and Setters
+    public Long getProductId() { 
+        return productId; 
+    }
+
+    public void setProductId(Long productId) { 
+        this.productId = productId; 
+    }
+
+    public String getBarcode() { 
+        return barcode; 
+    }
+
+    public void setBarcode(String barcode) { 
+        this.barcode = barcode;
+     }
+
+    public String getProductName() { 
+        return productName; 
+    }
+
+    public void setProductName(String productName) { 
+        this.productName = productName; 
+    }
+
+    public String getCategory() { 
+        return category; 
+    }
+
+    public void setCategory(String category) { 
+        this.category = category; 
+    }
+
+    public Double getSugars100g() { 
+        return sugars100g; 
+    }
+
+    public void setSugars100g(Double sugars100g) { 
+        this.sugars100g = sugars100g; 
+    }
+
+    public String getCountry() { 
+        return country; 
+    }
+
+    public void setCountry(String country) { 
+        this.country = country; 
+    }
+
+    public LocalDateTime getLastChecked() { return lastChecked; }
+    public void setLastChecked(LocalDateTime lastChecked) { this.lastChecked = lastChecked; }
+}

--- a/src/main/java/com/group/SwapSmart/model/ProductItem.java
+++ b/src/main/java/com/group/SwapSmart/model/ProductItem.java
@@ -39,7 +39,7 @@ public class ProductItem {
         @JsonProperty("sugars_100g")
         private Double sugars100g;
 
-        // Returns added_sugars_100g if available, otherwise falls back to sugars_100g
+        // Returns added-sugars_100g if available, otherwise falls back to sugars_100g
         public Double getEffectiveSugars() {
             return addedSugars100g != null ? addedSugars100g : sugars100g;
         }

--- a/src/main/java/com/group/SwapSmart/model/ProductItem.java
+++ b/src/main/java/com/group/SwapSmart/model/ProductItem.java
@@ -20,7 +20,7 @@ public class ProductItem {
     private String productName;
 
     // Categories list from API
-    @JsonProperty("categories_tags_en")
+    @JsonProperty("categories_tags")
     private List<String> categoryTags;
 
     // Nutriments object from API

--- a/src/main/java/com/group/SwapSmart/model/ProductItem.java
+++ b/src/main/java/com/group/SwapSmart/model/ProductItem.java
@@ -20,7 +20,7 @@ public class ProductItem {
     private String productName;
 
     // Categories list from API
-    @JsonProperty("categories_tags")
+    @JsonProperty("categories_tags_en")
     private List<String> categoryTags;
 
     // Nutriments object from API

--- a/src/main/java/com/group/SwapSmart/model/ProductItem.java
+++ b/src/main/java/com/group/SwapSmart/model/ProductItem.java
@@ -1,0 +1,66 @@
+package com.group.SwapSmart.model;
+/*
+This is a plain Java class representing the API response data from Open Food Facts. We are using this
+as the interface between grabbing JSON data from API and storing it in Product table.
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProductItem {
+
+    // Product barcode
+    @JsonProperty("code")
+    private String barcode;
+
+    // Product name
+    @JsonProperty("product_name")
+    private String productName;
+
+    // Categories list from API
+    @JsonProperty("categories_tags_en")
+    private List<String> categoryTags;
+
+    // Nutriments object from API
+    @JsonProperty("nutriments")
+    private Nutriments nutriments;
+
+    // Nested class to capture sugar values from nutriments object
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Nutriments {
+
+        // Preferred field
+        @JsonProperty("added-sugars_100g")
+        private Double addedSugars100g;
+
+        // Fallback field if added_sugars_100g is null
+        @JsonProperty("sugars_100g")
+        private Double sugars100g;
+
+        // Returns added_sugars_100g if available, otherwise falls back to sugars_100g
+        public Double getEffectiveSugars() {
+            return addedSugars100g != null ? addedSugars100g : sugars100g;
+        }
+
+        public Double getAddedSugars100g() { return addedSugars100g; }
+        public void setAddedSugars100g(Double addedSugars100g) { this.addedSugars100g = addedSugars100g; }
+
+        public Double getSugars100g() { return sugars100g; }
+        public void setSugars100g(Double sugars100g) { this.sugars100g = sugars100g; }
+    }
+
+    // Getters and Setters
+    public String getBarcode() { return barcode; }
+    public void setBarcode(String barcode) { this.barcode = barcode; }
+
+    public String getProductName() { return productName; }
+    public void setProductName(String productName) { this.productName = productName; }
+
+    public List<String> getCategoryTags() { return categoryTags; }
+    public void setCategoryTags(List<String> categoryTags) { this.categoryTags = categoryTags; }
+
+    public Nutriments getNutriments() { return nutriments; }
+    public void setNutriments(Nutriments nutriments) { this.nutriments = nutriments; }
+}

--- a/src/main/java/com/group/SwapSmart/model/ProductResponse.java
+++ b/src/main/java/com/group/SwapSmart/model/ProductResponse.java
@@ -1,0 +1,17 @@
+package com.group.SwapSmart.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Wrapper class to map the OpenFoodFacts single product response
+// The API returns product data nested inside a "product" object
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProductResponse {
+
+    // Maps to the "product" object in the API response
+    @JsonProperty("product")
+    private ProductItem product;
+
+    public ProductItem getProduct() { return product; }
+    public void setProduct(ProductItem product) { this.product = product; }
+}

--- a/src/main/java/com/group/SwapSmart/model/SearchResponse.java
+++ b/src/main/java/com/group/SwapSmart/model/SearchResponse.java
@@ -1,0 +1,21 @@
+package com.group.SwapSmart.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/*
+ Wrapper class to map the OpenFoodFacts search response.
+ The API returns results nested inside a "products" array so we need
+ this class to extract the list before passing it to the service.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchResponse {
+
+    // Maps to the "products" array in the API response
+    @JsonProperty("products")
+    private List<ProductItem> products;
+
+    public List<ProductItem> getProducts() { return products; }
+    public void setProducts(List<ProductItem> products) { this.products = products; }
+}

--- a/src/main/java/com/group/SwapSmart/repository/ProductRepository.java
+++ b/src/main/java/com/group/SwapSmart/repository/ProductRepository.java
@@ -1,0 +1,14 @@
+package com.group.SwapSmart.repository;
+
+import com.group.SwapSmart.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    // Find a product by barcode to check if it's already cached
+    Optional<Product> findByBarcode(String barcode);
+
+}

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -9,10 +9,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,7 +28,7 @@ public class AlternativesService {
     private static final String BASE_URL = "https://world.openfoodfacts.org/api/v2";
 
     // Sugar threshold for alternatives search
-    private static final double SUGAR_THRESHOLD = 2;
+    private static final double SUGAR_THRESHOLD = 5;
 
     // Constructor injection
     public AlternativesService(ProductRepository productsRepository) {
@@ -41,6 +43,7 @@ public class AlternativesService {
         Optional<Product> cachedProduct = productsRepository.findByBarcode(barcode);
 
         String category;
+        List<Product> alternatives;
 
         if (cachedProduct.isPresent()) {
             // Product already cached, grab category from DB instead of calling API
@@ -56,9 +59,9 @@ public class AlternativesService {
 
             // grabbing the whole list of category tags here
             List<String> tags = productItem.getCategoryTags();
-            System.out.println("Tags: " + tags); // for testing, need to delete
 
             //IMPORTANT: here, if no categories can be found, we just return immutable list; need to change logic to handle this scenario
+            // maybe look into other related tags
             // null check in case category tags is empty or doesn't exist for product scanned
             if (tags == null || tags.isEmpty()) {
                System.out.println("No categories info available");
@@ -66,10 +69,22 @@ public class AlternativesService {
             }
 
             // Grab most specific category tag from the API response (last item in list)
-            category = tags.get(tags.size() - 1);
+           category = tags.get(tags.size() - 1);
+
+           /*
+           Trying for category hierarchy to get more results below
+            */
+           // searching for alternatives first with most specific/last category
+           alternatives = fetchAlternatives(category);
+
+           if (alternatives.isEmpty() && tags.size() > 1) { // if we get empty list (AKA no alts), and there is >1 category, check second to last category
+            category = tags.get(tags.size() - 2); 
+           } else {
+            System.out.println("Exhausted category hierarchy up to 2 most specific");
+           }
 
             // Save product to DB for future lookups
-            saveProduct(productItem);
+            saveProduct(productItem, category);
         }
 
         // Step 2: Search for sugar free alternatives in the same category
@@ -97,69 +112,67 @@ public class AlternativesService {
         
     }
 
-    // Searches OpenFoodFacts for sugar free alternatives in the given category AND with the No Sugar label
-    private List<Product> fetchAlternatives(String category) {  
-        // Call search API with No Sugar label and category filters combined
+    // Searches OpenFoodFacts for sugar free alternatives in the given category AND with the No Added Sugar label
+    private List<Product> fetchAlternatives(String category) {
         try {
-            // URL encode category to handle spaces and special characters
-            String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8);
-            SearchResponse response = restClient.get()
-                .uri(BASE_URL + "/search?categories_tags_en=" + encodedCategory +
-                "&labels_tags=en:no-sugar" +
+            // URL encode category to handle spaces and special characters; also replacing the + in HTML style encoding to %20 
+            String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8).replace("+", "%20");
+    
+            // Build URL with encoded special characters to prevent URL parsing issues
+            // Colons in query param values must be encoded as %3A
+            // Commas in fields list must be encoded as %2C
+            String url = BASE_URL + "/search" +
+                "?categories_tags_en=" + encodedCategory +
+                "&labels_tags=en:no-added-sugars" +
                 "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
-                "&countries_tags=en:united-states" +
+                "&countries_tags=en:united-states" +    
                 "&fields=product_name,code,categories_tags_en,nutriments" +
-                "&page_size=10")
-                .retrieve()
-                .body(SearchResponse.class);
+                "&page_size=10";
 
-            // null checking here because RestClientException doesn't include null
-            if (response == null || response.getProducts() == null) { // checks if response null or if product list null
+            // System.out.println("Fetching alternatives with URL: " + url); // debug statement
+
+            SearchResponse response = restClient.get()
+                    .uri(URI.create(url))
+                    .retrieve()
+                    .body(SearchResponse.class);
+    
+            // Null check here because RestClientException doesn't include null
+            // Checks if response is null or if product list within response is null
+            if (response == null || response.getProducts() == null) {
                 return List.of();
             }
-
-        // Secondary Java filter to catch any products that slipped through
-        // then map to Product entity and return top 3
+    
+            // Secondary Java filter to catch any products that slipped through the API filter
+            // then map to Product entity and return top 3
             return response.getProducts().stream()
                     .filter(item -> item.getNutriments() != null &&
                             item.getNutriments().getEffectiveSugars() != null &&
                             item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
+                    .sorted(Comparator.comparingDouble(item -> item.getNutriments().getEffectiveSugars()))
                     .limit(3)
                     .map(this::mapToProduct)
                     .toList();
+    
         } catch (RestClientException e) {
-            System.out.println("Error with API data not matching up with our filtering/criteria. Returning empty list");
+            // Log actual error message for debugging
+            System.out.println("RestClient error: " + e.getMessage());
             return List.of();
         }
-        
     }
 
         // Saves a new product to the DB
-    private void saveProduct(ProductItem productItem) {
-        Product product = mapToProduct(productItem);
+    private void saveProduct(ProductItem productItem, String category) {
+        Product product = mapToProduct(productItem, category);
         product.setLastChecked(LocalDateTime.now());
         productsRepository.save(product);
     }
 
     // Maps a ProductItem (API response) to a Products entity (DB)
-    private Product mapToProduct(ProductItem item) {
+    private Product mapToProduct(ProductItem item, String category) {
         Product product = new Product();
         product.setBarcode(item.getBarcode());
         product.setProductName(item.getProductName());
-
-        // Grab most specific category tag from the list (last item)
-        // if (item.getCategoryTags() != null && !item.getCategoryTags().isEmpty()) {
-        //     product.setCategory(item.getCategoryTags().get(item.getCategoryTags().size() - 1));
-        // }
-
-        if (item.getCategoryTags() != null && !item.getCategoryTags().isEmpty()) {
-            List<String> tags = item.getCategoryTags();
-            String chosen = tags.stream()
-                    .filter(t -> t != null && t.startsWith("en:"))
-                    .reduce((first, last) -> last)
-                    .orElse(tags.get(tags.size() - 1));
-            product.setCategory(chosen);
-        }
+        product.setCategory(category);
 
         // Use effective sugars (added-sugars_100g if available, otherwise sugars_100g)
         if (item.getNutriments() != null) {
@@ -170,5 +183,10 @@ public class AlternativesService {
         product.setLastChecked(LocalDateTime.now());
         return product;
     }
-    //TODO: Look into FatSecret API, as OpenFoodFacts keeps producing unreliability issues
+
+    // Used for mapping alternatives returned from search (not saved to DB)
+    private Product mapToProduct(ProductItem item) {
+        return mapToProduct(item, null);
+    }
+   
 }

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -53,22 +56,17 @@ public class AlternativesService {
 
             // grabbing the whole list of category tags here
             List<String> tags = productItem.getCategoryTags();
+            System.out.println("Tags: " + tags); // for testing, need to delete
 
+            //IMPORTANT: here, if no categories can be found, we just return immutable list; need to change logic to handle this scenario
             // null check in case category tags is empty or doesn't exist for product scanned
             if (tags == null || tags.isEmpty()) {
                System.out.println("No categories info available");
                return List.of();
             }
 
-            // grab last category/most specific category 
-            
-            category = tags.stream()
-                .filter(t -> t != null && t.startsWith("en:"))
-                .reduce((first, last) -> last)     // take the last en: tag (most specific in that subset)
-                .orElse(tags.get(tags.size() - 1)); // fallback if no en: tags exist
-
             // Grab most specific category tag from the API response (last item in list)
-            // category = productItem.getCategoryTags().get(productItem.getCategoryTags().size() - 1);
+            category = tags.get(tags.size() - 1);
 
             // Save product to DB for future lookups
             saveProduct(productItem);
@@ -82,7 +80,7 @@ public class AlternativesService {
     private ProductItem fetchProductByBarcode(String barcode) { 
         try {
             ProductResponse response = restClient.get()
-            .uri(BASE_URL + "/product/" + barcode + "?fields=product_name,code,categories_tags,nutriments")
+            .uri(BASE_URL + "/product/" + barcode + "?fields=product_name,code,categories_tags_en,nutriments")
             .retrieve()
             .body(ProductResponse.class);
 
@@ -103,12 +101,14 @@ public class AlternativesService {
     private List<Product> fetchAlternatives(String category) {  
         // Call search API with No Sugar label and category filters combined
         try {
+            // URL encode category to handle spaces and special characters
+            String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8);
             SearchResponse response = restClient.get()
-                .uri(BASE_URL + "/search?categories_tags=" + category +
+                .uri(BASE_URL + "/search?categories_tags_en=" + encodedCategory +
                 "&labels_tags=en:no-sugar" +
-                "&sugars_100g<=" + SUGAR_THRESHOLD +
+                "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
                 "&countries_tags=en:united-states" +
-                "&fields=product_name,code,categories_tags,nutriments" +
+                "&fields=product_name,code,categories_tags_en,nutriments" +
                 "&page_size=10")
                 .retrieve()
                 .body(SearchResponse.class);
@@ -161,7 +161,7 @@ public class AlternativesService {
             product.setCategory(chosen);
         }
 
-        // Use effective sugars (added_sugars_100g if available, otherwise sugars_100g)
+        // Use effective sugars (added-sugars_100g if available, otherwise sugars_100g)
         if (item.getNutriments() != null) {
             product.setSugars100g(item.getNutriments().getEffectiveSugars());
         }
@@ -170,6 +170,5 @@ public class AlternativesService {
         product.setLastChecked(LocalDateTime.now());
         return product;
     }
-
-//TODO: check why not returning simple sugar free alt such as coke zero for a coke scan
+    //TODO: Look into FatSecret API, as OpenFoodFacts keeps producing unreliability issues
 }

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -48,6 +48,7 @@ public class AlternativesService {
         if (cachedProduct.isPresent()) {
             // Product already cached, grab category from DB instead of calling API
             category = cachedProduct.get().getCategory();
+            alternatives = fetchAlternatives(category);
         } else {
             // Product not cached, call API to get product info
             ProductItem productItem = fetchProductByBarcode(barcode);
@@ -68,6 +69,8 @@ public class AlternativesService {
                return List.of();
             }
 
+            // Step 2: Search for sugar free alternatives in the same category
+
             // Grab most specific category tag from the API response (last item in list)
            category = tags.get(tags.size() - 1);
 
@@ -80,15 +83,15 @@ public class AlternativesService {
            if (alternatives.isEmpty() && tags.size() > 1) { // if we get empty list (AKA no alts), and there is >1 category, check second to last category
             category = tags.get(tags.size() - 2); 
            } else {
-            System.out.println("Exhausted category hierarchy up to 2 most specific");
+            System.out.println("Exhausted category hierarchy (only had 1 category tag)");
            }
 
             // Save product to DB for future lookups
             saveProduct(productItem, category);
         }
 
-        // Step 2: Search for sugar free alternatives in the same category
-        return fetchAlternatives(category);
+        // whether we grab alternatives by finding product from db, or exhausting category hierarchy, we return what we fetch here
+        return alternatives;
     }
 
    // Calls OpenFoodFacts API to get product info by barcode
@@ -106,7 +109,7 @@ public class AlternativesService {
             }
 
         } catch (RestClientException e) {
-            System.out.println("Error with calling API to get product data by barcode");
+            System.out.println("Error with calling API to get product data by barcode " + e.getMessage());
             return null;
         }
         

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -7,6 +7,8 @@ import com.group.SwapSmart.model.SearchResponse;
 import com.group.SwapSmart.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -21,7 +23,7 @@ public class AlternativesService {
     private static final String BASE_URL = "https://world.openfoodfacts.org/api/v2";
 
     // Sugar threshold for alternatives search
-    private static final double SUGAR_THRESHOLD = 20;
+    private static final double SUGAR_THRESHOLD = 2;
 
     // Constructor injection
     public AlternativesService(ProductRepository productsRepository) {
@@ -44,8 +46,29 @@ public class AlternativesService {
             // Product not cached, call API to get product info
             ProductItem productItem = fetchProductByBarcode(barcode);
 
+            if (productItem == null) { // if we got null from fetchProductByBarcode, then handled here by returning immutable list
+                System.out.println("Could not grab item info from API, so cannot get alternatives");
+                return List.of();
+            }
+
+            // grabbing the whole list of category tags here
+            List<String> tags = productItem.getCategoryTags();
+
+            // null check in case category tags is empty or doesn't exist for product scanned
+            if (tags == null || tags.isEmpty()) {
+               System.out.println("No categories info available");
+               return List.of();
+            }
+
+            // grab last category/most specific category 
+            
+            category = tags.stream()
+                .filter(t -> t != null && t.startsWith("en:"))
+                .reduce((first, last) -> last)     // take the last en: tag (most specific in that subset)
+                .orElse(tags.get(tags.size() - 1)); // fallback if no en: tags exist
+
             // Grab most specific category tag from the API response (last item in list)
-            category = productItem.getCategoryTags().get(productItem.getCategoryTags().size() - 1);
+            // category = productItem.getCategoryTags().get(productItem.getCategoryTags().size() - 1);
 
             // Save product to DB for future lookups
             saveProduct(productItem);
@@ -57,38 +80,61 @@ public class AlternativesService {
 
    // Calls OpenFoodFacts API to get product info by barcode
     private ProductItem fetchProductByBarcode(String barcode) { 
-        ProductResponse response = restClient.get()
-            .uri(BASE_URL + "/product/" + barcode + "?fields=product_name,code,categories_tags_en,nutriments")
+        try {
+            ProductResponse response = restClient.get()
+            .uri(BASE_URL + "/product/" + barcode + "?fields=product_name,code,categories_tags,nutriments")
             .retrieve()
             .body(ProductResponse.class);
 
-        return response.getProduct();
+            if (response != null) { // null check here because RestClientException doesn't include null 
+                return response.getProduct();
+            } else {
+                return null;
+            }
+
+        } catch (RestClientException e) {
+            System.out.println("Error with calling API to get product data by barcode");
+            return null;
+        }
+        
     }
 
-    // Searches OpenFoodFacts for sugar free alternatives in the given category
-    private List<Product> fetchAlternatives(String category) {
-        // Call search API with category and sugar threshold filters
-        SearchResponse response = restClient.get()
-            .uri(BASE_URL + "/search?categories_tags_en=" + category +
-                    "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
-                    "&countries_tags_en=united-states" +
-                    "&fields=product_name,code,categories_tags_en,nutriments" +
-                    "&page_size=10")
-            .retrieve()
-            .body(SearchResponse.class);
+    // Searches OpenFoodFacts for sugar free alternatives in the given category AND with the No Sugar label
+    private List<Product> fetchAlternatives(String category) {  
+        // Call search API with No Sugar label and category filters combined
+        try {
+            SearchResponse response = restClient.get()
+                .uri(BASE_URL + "/search?categories_tags=" + category +
+                "&labels_tags=en:no-sugar" +
+                "&sugars_100g<=" + SUGAR_THRESHOLD +
+                "&countries_tags=en:united-states" +
+                "&fields=product_name,code,categories_tags,nutriments" +
+                "&page_size=10")
+                .retrieve()
+                .body(SearchResponse.class);
 
-    // Secondary Java filter to catch any products that slipped through the API filter
-    // then map to Product entity and return top 3
-        return response.getProducts().stream()
-            .filter(item -> item.getNutriments() != null &&
-                    item.getNutriments().getEffectiveSugars() != null &&
-                    item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
-            .limit(3)
-            .map(this::mapToProduct)
-            .toList();
+            // null checking here because RestClientException doesn't include null
+            if (response == null || response.getProducts() == null) { // checks if response null or if product list null
+                return List.of();
+            }
+
+        // Secondary Java filter to catch any products that slipped through
+        // then map to Product entity and return top 3
+            return response.getProducts().stream()
+                    .filter(item -> item.getNutriments() != null &&
+                            item.getNutriments().getEffectiveSugars() != null &&
+                            item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
+                    .limit(3)
+                    .map(this::mapToProduct)
+                    .toList();
+        } catch (RestClientException e) {
+            System.out.println("Error with API data not matching up with our filtering/criteria. Returning empty list");
+            return List.of();
+        }
+        
     }
 
-    // Saves a new product to the DB
+        // Saves a new product to the DB
     private void saveProduct(ProductItem productItem) {
         Product product = mapToProduct(productItem);
         product.setLastChecked(LocalDateTime.now());
@@ -102,8 +148,17 @@ public class AlternativesService {
         product.setProductName(item.getProductName());
 
         // Grab most specific category tag from the list (last item)
+        // if (item.getCategoryTags() != null && !item.getCategoryTags().isEmpty()) {
+        //     product.setCategory(item.getCategoryTags().get(item.getCategoryTags().size() - 1));
+        // }
+
         if (item.getCategoryTags() != null && !item.getCategoryTags().isEmpty()) {
-            product.setCategory(item.getCategoryTags().get(item.getCategoryTags().size() - 1));
+            List<String> tags = item.getCategoryTags();
+            String chosen = tags.stream()
+                    .filter(t -> t != null && t.startsWith("en:"))
+                    .reduce((first, last) -> last)
+                    .orElse(tags.get(tags.size() - 1));
+            product.setCategory(chosen);
         }
 
         // Use effective sugars (added_sugars_100g if available, otherwise sugars_100g)
@@ -115,4 +170,6 @@ public class AlternativesService {
         product.setLastChecked(LocalDateTime.now());
         return product;
     }
+
+//TODO: check why not returning simple sugar free alt such as coke zero for a coke scan
 }

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -46,10 +46,16 @@ public class AlternativesService {
         List<Product> alternatives;
         ProductItem productItem;
         List<String> tags;
+        double sugarThreshold;
 
         if (cachedProduct.isPresent()) {
             // Product already cached, grab category from DB instead of calling API
             category = cachedProduct.get().getCategory();
+            // grabbing sugar from db, but if null, set threshold to defined one in class
+            sugarThreshold = cachedProduct.get().getSugars100g() != null 
+            ? cachedProduct.get().getSugars100g() 
+            : SUGAR_THRESHOLD;
+
             // alternatives = fetchAlternativesWithLabel(category);
         } else {
             // Product not cached, call API to get product info
@@ -62,6 +68,7 @@ public class AlternativesService {
 
             // grabbing the whole list of category tags here
             tags = productItem.getCategoryTags();
+            // System.out.println("Category tags from OFF: " + tags);
 
             //if no categories can be found, we just return immutable list; need to change logic to handle this scenario
             // maybe look into other related tags
@@ -75,6 +82,10 @@ public class AlternativesService {
 
             // Grab most specific category tag from the API response (last item in list)
             category = tags.get(tags.size() - 1);
+            // grab sugar_100g from product item and set as sugar threshold, or fallback to defined sugar threshold if null
+            sugarThreshold = productItem.getNutriments() != null && productItem.getNutriments().getSugars100g() != null 
+            ? productItem.getNutriments().getSugars100g() 
+            : SUGAR_THRESHOLD; 
 
             // Trying for category hierarchy to get more results below
     
@@ -87,7 +98,7 @@ public class AlternativesService {
             } 
 
             if (alternatives.isEmpty()) {
-                alternatives = fetchAlternativesBySugar(category);
+                alternatives = fetchAlternativesBySugar(category, sugarThreshold);
             }
 
             // Save product to DB for future lookups
@@ -103,7 +114,7 @@ public class AlternativesService {
         alternatives = fetchAlternativesWithLabel(category);
 
         if (alternatives.isEmpty()) {
-            alternatives = fetchAlternativesBySugar(category);
+            alternatives = fetchAlternativesBySugar(category, sugarThreshold);
         }
        
         // returning alts from cached product
@@ -177,13 +188,13 @@ public class AlternativesService {
         }
     }
 
-    private  List<Product> fetchAlternativesBySugar(String category) {
+    private  List<Product> fetchAlternativesBySugar(String category, double sugarThreshold) {
         try {
             String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8).replace("+", "%20");
 
             String url = BASE_URL + "/search" +
             "?categories_tags_en=" + encodedCategory +
-            "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
+            "&nutriments_sugars_100g_max=" + sugarThreshold +
             "&countries_tags=en:united-states" +
             "&fields=product_name,code,categories_tags_en,nutriments" +
             "&page_size=10";
@@ -199,9 +210,9 @@ public class AlternativesService {
 
             return response.getProducts().stream()
                     .filter(item -> item.getNutriments() != null &&
-                        item.getNutriments().getEffectiveSugars() != null &&
-                        item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
-                    .sorted(Comparator.comparingDouble(item -> item.getNutriments().getEffectiveSugars()))
+                        item.getNutriments().getSugars100g() != null &&
+                        item.getNutriments().getSugars100g() < sugarThreshold)
+                    .sorted(Comparator.comparingDouble(item -> item.getNutriments().getSugars100g()))
                     .limit(3)
                     .map(this::mapToProduct)
                     .toList();

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -1,0 +1,118 @@
+package com.group.SwapSmart.service;
+
+import com.group.SwapSmart.entity.Product;
+import com.group.SwapSmart.model.ProductItem;
+import com.group.SwapSmart.model.ProductResponse;
+import com.group.SwapSmart.model.SearchResponse;
+import com.group.SwapSmart.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AlternativesService {
+
+    private final ProductRepository productsRepository;
+    private final RestClient restClient;
+
+    // Base URL for OpenFoodFacts API
+    private static final String BASE_URL = "https://world.openfoodfacts.org/api/v2";
+
+    // Sugar threshold for alternatives search
+    private static final double SUGAR_THRESHOLD = 20;
+
+    // Constructor injection
+    public AlternativesService(ProductRepository productsRepository) {
+        this.productsRepository = productsRepository;
+        this.restClient = RestClient.create();
+    }
+
+    // Main method: takes a barcode and returns a list of sugar free alternatives
+    public List<Product> getAlternatives(String barcode) {
+
+        // Step 1: Check if product is already cached in DB
+        Optional<Product> cachedProduct = productsRepository.findByBarcode(barcode);
+
+        String category;
+
+        if (cachedProduct.isPresent()) {
+            // Product already cached, grab category from DB instead of calling API
+            category = cachedProduct.get().getCategory();
+        } else {
+            // Product not cached, call API to get product info
+            ProductItem productItem = fetchProductByBarcode(barcode);
+
+            // Grab most specific category tag from the API response (last item in list)
+            category = productItem.getCategoryTags().get(productItem.getCategoryTags().size() - 1);
+
+            // Save product to DB for future lookups
+            saveProduct(productItem);
+        }
+
+        // Step 2: Search for sugar free alternatives in the same category
+        return fetchAlternatives(category);
+    }
+
+   // Calls OpenFoodFacts API to get product info by barcode
+    private ProductItem fetchProductByBarcode(String barcode) { 
+        ProductResponse response = restClient.get()
+            .uri(BASE_URL + "/product/" + barcode + "?fields=product_name,code,categories_tags_en,nutriments")
+            .retrieve()
+            .body(ProductResponse.class);
+
+        return response.getProduct();
+    }
+
+    // Searches OpenFoodFacts for sugar free alternatives in the given category
+    private List<Product> fetchAlternatives(String category) {
+        // Call search API with category and sugar threshold filters
+        SearchResponse response = restClient.get()
+            .uri(BASE_URL + "/search?categories_tags_en=" + category +
+                    "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
+                    "&countries_tags_en=united-states" +
+                    "&fields=product_name,code,categories_tags_en,nutriments" +
+                    "&page_size=10")
+            .retrieve()
+            .body(SearchResponse.class);
+
+    // Secondary Java filter to catch any products that slipped through the API filter
+    // then map to Product entity and return top 3
+        return response.getProducts().stream()
+            .filter(item -> item.getNutriments() != null &&
+                    item.getNutriments().getEffectiveSugars() != null &&
+                    item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
+            .limit(3)
+            .map(this::mapToProduct)
+            .toList();
+    }
+
+    // Saves a new product to the DB
+    private void saveProduct(ProductItem productItem) {
+        Product product = mapToProduct(productItem);
+        product.setLastChecked(LocalDateTime.now());
+        productsRepository.save(product);
+    }
+
+    // Maps a ProductItem (API response) to a Products entity (DB)
+    private Product mapToProduct(ProductItem item) {
+        Product product = new Product();
+        product.setBarcode(item.getBarcode());
+        product.setProductName(item.getProductName());
+
+        // Grab most specific category tag from the list (last item)
+        if (item.getCategoryTags() != null && !item.getCategoryTags().isEmpty()) {
+            product.setCategory(item.getCategoryTags().get(item.getCategoryTags().size() - 1));
+        }
+
+        // Use effective sugars (added_sugars_100g if available, otherwise sugars_100g)
+        if (item.getNutriments() != null) {
+            product.setSugars100g(item.getNutriments().getEffectiveSugars());
+        }
+
+        product.setCountry("united-states");
+        product.setLastChecked(LocalDateTime.now());
+        return product;
+    }
+}

--- a/src/main/java/com/group/SwapSmart/service/AlternativesService.java
+++ b/src/main/java/com/group/SwapSmart/service/AlternativesService.java
@@ -44,14 +44,16 @@ public class AlternativesService {
 
         String category;
         List<Product> alternatives;
+        ProductItem productItem;
+        List<String> tags;
 
         if (cachedProduct.isPresent()) {
             // Product already cached, grab category from DB instead of calling API
             category = cachedProduct.get().getCategory();
-            alternatives = fetchAlternatives(category);
+            // alternatives = fetchAlternativesWithLabel(category);
         } else {
             // Product not cached, call API to get product info
-            ProductItem productItem = fetchProductByBarcode(barcode);
+            productItem = fetchProductByBarcode(barcode);
 
             if (productItem == null) { // if we got null from fetchProductByBarcode, then handled here by returning immutable list
                 System.out.println("Could not grab item info from API, so cannot get alternatives");
@@ -59,9 +61,9 @@ public class AlternativesService {
             }
 
             // grabbing the whole list of category tags here
-            List<String> tags = productItem.getCategoryTags();
+            tags = productItem.getCategoryTags();
 
-            //IMPORTANT: here, if no categories can be found, we just return immutable list; need to change logic to handle this scenario
+            //if no categories can be found, we just return immutable list; need to change logic to handle this scenario
             // maybe look into other related tags
             // null check in case category tags is empty or doesn't exist for product scanned
             if (tags == null || tags.isEmpty()) {
@@ -72,25 +74,39 @@ public class AlternativesService {
             // Step 2: Search for sugar free alternatives in the same category
 
             // Grab most specific category tag from the API response (last item in list)
-           category = tags.get(tags.size() - 1);
+            category = tags.get(tags.size() - 1);
 
-           /*
-           Trying for category hierarchy to get more results below
-            */
-           // searching for alternatives first with most specific/last category
-           alternatives = fetchAlternatives(category);
+            // Trying for category hierarchy to get more results below
+    
+            // searching for alternatives first with most specific/last category
+            alternatives = fetchAlternativesWithLabel(category);
 
-           if (alternatives.isEmpty() && tags.size() > 1) { // if we get empty list (AKA no alts), and there is >1 category, check second to last category
-            category = tags.get(tags.size() - 2); 
-           } else {
-            System.out.println("Exhausted category hierarchy (only had 1 category tag)");
-           }
+            if (alternatives.isEmpty() && tags.size() > 1) { // if we get empty list (AKA no alts), and there is >1 category, check second to last category
+                category = tags.get(tags.size() - 2); 
+                alternatives = fetchAlternativesWithLabel(category);
+            } 
+
+            if (alternatives.isEmpty()) {
+                alternatives = fetchAlternativesBySugar(category);
+            }
 
             // Save product to DB for future lookups
             saveProduct(productItem, category);
+
+            // returning alts found from first time barcode scan
+            return alternatives;
         }
 
-        // whether we grab alternatives by finding product from db, or exhausting category hierarchy, we return what we fetch here
+         // this is if we grab category from db cache, so we don't need to do any category work. just grab cached category
+        // and try with no added sugar label. if no results, try by sugar
+
+        alternatives = fetchAlternativesWithLabel(category);
+
+        if (alternatives.isEmpty()) {
+            alternatives = fetchAlternativesBySugar(category);
+        }
+       
+        // returning alts from cached product
         return alternatives;
     }
 
@@ -116,14 +132,12 @@ public class AlternativesService {
     }
 
     // Searches OpenFoodFacts for sugar free alternatives in the given category AND with the No Added Sugar label
-    private List<Product> fetchAlternatives(String category) {
+    private List<Product> fetchAlternativesWithLabel(String category) {
         try {
             // URL encode category to handle spaces and special characters; also replacing the + in HTML style encoding to %20 
             String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8).replace("+", "%20");
     
             // Build URL with encoded special characters to prevent URL parsing issues
-            // Colons in query param values must be encoded as %3A
-            // Commas in fields list must be encoded as %2C
             String url = BASE_URL + "/search" +
                 "?categories_tags_en=" + encodedCategory +
                 "&labels_tags=en:no-added-sugars" +
@@ -161,6 +175,42 @@ public class AlternativesService {
             System.out.println("RestClient error: " + e.getMessage());
             return List.of();
         }
+    }
+
+    private  List<Product> fetchAlternativesBySugar(String category) {
+        try {
+            String encodedCategory = URLEncoder.encode(category, StandardCharsets.UTF_8).replace("+", "%20");
+
+            String url = BASE_URL + "/search" +
+            "?categories_tags_en=" + encodedCategory +
+            "&nutriments_sugars_100g_max=" + SUGAR_THRESHOLD +
+            "&countries_tags=en:united-states" +
+            "&fields=product_name,code,categories_tags_en,nutriments" +
+            "&page_size=10";
+
+            SearchResponse response = restClient.get()
+                    .uri(URI.create(url))
+                    .retrieve()
+                    .body(SearchResponse.class);
+
+            if (response == null || response.getProducts() == null) {
+                return List.of();
+            }
+
+            return response.getProducts().stream()
+                    .filter(item -> item.getNutriments() != null &&
+                        item.getNutriments().getEffectiveSugars() != null &&
+                        item.getNutriments().getEffectiveSugars() <= SUGAR_THRESHOLD)
+                    .sorted(Comparator.comparingDouble(item -> item.getNutriments().getEffectiveSugars()))
+                    .limit(3)
+                    .map(this::mapToProduct)
+                    .toList();
+
+        } catch (RestClientException e) {
+            System.out.println("Error fetching data with API Call for fetchAlternativesBySugar: " + e.getMessage());
+            return List.of();
+        }
+        
     }
 
         // Saves a new product to the DB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 # Below line makes sure table is made if it doesn't exist
 spring.jpa.hibernate.ddl-auto=update
 
-
 # Temporarily disabling Spring Security for now
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,8 @@ spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+# Below line makes sure table is made if it doesn't exist
+spring.jpa.hibernate.ddl-auto=update
 
 
 # Temporarily disabling Spring Security for now


### PR DESCRIPTION
Addresses issues #12 and #8 
Created products table and all needed files (service, controller, model) to call to external OpenFoodFacts API to grab nutritional info on product. Product is then cached into DB if not yet in there, and a query with parameters done to external API again to grab results with No Added Sugar label. If not available, grab lesser sugar results. 